### PR TITLE
add pico-sdk as submodule; fix warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-firmware/pico-sdk
 firmware/source/build/
 firmware/source/config.h
 examples/external/ressources/sound/music.wav

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "firmware/pico-sdk"]
+	path = firmware/pico-sdk
+	url = https://github.com/raspberrypi/pico-sdk.git

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -23,11 +23,7 @@ Then reboot or reload udev rules:
 
 ## Build firmware
 
-In u2if/firmware/, clone pico-sdk (v1.1.0):
- - git clone https://github.com/raspberrypi/pico-sdk.git
- - cd pico-sdk
- - git reset --hard 1.1.0
- - git submodule update --init
+ - git submodule update --init   # Bring in pico-sdk submodule
 
 In u2if/firmware/source directory:
  - mkdir build
@@ -36,4 +32,3 @@ In u2if/firmware/source directory:
  - make
 
 The firmware to upload to Pico is u2if/firmware/source/build/u2if.uf2
-

--- a/firmware/source/interfaces/Pwm.h
+++ b/firmware/source/interfaces/Pwm.h
@@ -25,7 +25,7 @@ struct Slice {
             return gpioChannelB = gpio;
     }
 
-    inline bool unsetGpioChannel(uint channel) {
+    inline void unsetGpioChannel(uint channel) {
         if(channel == 0)
             gpioChannelA = -1;
         else
@@ -60,4 +60,3 @@ protected:
 
 
 #endif
-

--- a/firmware/source/interfaces/StreamBuffer.h
+++ b/firmware/source/interfaces/StreamBuffer.h
@@ -12,7 +12,7 @@ public:
     inline uint32_t getAllocateSize() const {return static_cast<uint32_t>(_buffer.size()*4);}
     inline uint8_t* getDataPtr8() {return (uint8_t*)_buffer.data();}
     inline uint32_t* getDataPtr32() {return static_cast<uint32_t*>(_buffer.data());}
-    inline uint32_t setSize(uint32_t size) {_bufSize = size;}
+    inline void setSize(uint32_t size) {_bufSize = size;}
     inline uint32_t size() const {return _bufSize;}
 protected:
     //std::vector<uint8_t> _buffer;
@@ -22,4 +22,3 @@ protected:
 
 
 #endif
-


### PR DESCRIPTION
Previous, with gcc9 and gcc10, compiled to faulty code that caused `StreamedInterface::streamRxRead()` to loop infinitely.

There were a couple of compiler warnings which I fixed, and I think that may have solved the problem. In particular, `StreamBuffer::setSize()` is called from `StreamInterface::streamRxRead()`, and `setSize()` was declared as returning a value even though it did not. (There was a similar declaration error in `Pwm.h` as well.)

@caternuson Could you try this again with gcc10, and test? I only looked at the assembly output, and the previous infinite loop is gone. It is still a compiler bug that this happened at all, though.

Also I added `pico-sdk` as a submodule to avoid some manual git steps.