### PR TITLE
Add boards to ci that are supported in build-all.sh

### DIFF
--- a/.github/workflows/build_uf2.yml
+++ b/.github/workflows/build_uf2.yml
@@ -10,15 +10,15 @@ jobs:
       - name: Install gcc-arm
         uses: carlosperate/arm-none-eabi-gcc-action@v1
         with:
-          release: '10-2020-q4'
+          release: "10-2020-q4"
       - name: Get pico-sdk submodule
         run: git submodule update --init --recursive
-#-- HACK-----------------------------------------------------------
-# needed for older pico-sdk, see here for more info:
-# https://github.com/raspberrypi/pico-sdk/pull/457
+      #-- HACK-----------------------------------------------------------
+      # needed for older pico-sdk, see here for more info:
+      # https://github.com/raspberrypi/pico-sdk/pull/457
       - name: Patch pico-sdk for crystal startup
         run: sed -i 's/xosc_hw->startup = startup_delay;/xosc_hw->startup = startup_delay * 64;/' firmware/pico-sdk/src/rp2_common/hardware_xosc/xosc.c
-#-- HACK-----------------------------------------------------------
+      #-- HACK-----------------------------------------------------------
       - name: Build firmwares
         run: |
           arm-none-eabi-gcc --version
@@ -30,6 +30,11 @@ jobs:
           cmake -DBOARD=QTPY .. ; make ; mv u2if.uf2 u2if_qtpy.uf2
           cmake -DBOARD=ITSYBITSY .. ; make ; mv u2if.uf2 u2if_itsybitsy.uf2
           cmake -DBOARD=QT2040_TRINKEY .. ; make ; mv u2if.uf2 u2if_trinkey.uf2
+          cmake -DBOARD=FEATHER_EPD .. ; make ; mv u2if.uf2 u2if_trinkey.uf2
+          cmake -DBOARD=FEATHER_RFM .. ; make ; mv u2if.uf2 u2if_trinkey.uf2
+          cmake -DBOARD=FEATHER_CAN .. ; make ; mv u2if.uf2 u2if_trinkey.uf2
+          cmake -DBOARD=KB2040 .. ; make ; mv u2if.uf2 u2if_trinkey.uf2
+
           ls -l u2if_*.uf2
       - name: Add Build Artifacts to CI Run
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_uf2.yml
+++ b/.github/workflows/build_uf2.yml
@@ -27,13 +27,13 @@ jobs:
           cd build
           cmake -DBOARD=PICO .. ; make ; mv u2if.uf2 u2if_pico.uf2
           cmake -DBOARD=FEATHER .. ; make ; mv u2if.uf2 u2if_feather.uf2
-          cmake -DBOARD=QTPY .. ; make ; mv u2if.uf2 u2if_qtpy.uf2
+          cmake -DBOARD=FEATHER_EPD .. ; make ; mv u2if.uf2 u2if_feather_epd.uf2
+          cmake -DBOARD=FEATHER_RFM .. ; make ; mv u2if.uf2 u2if_feather_rfm.uf2
+          cmake -DBOARD=FEATHER_CAN .. ; make ; mv u2if.uf2 u2if_feather_can.uf2
           cmake -DBOARD=ITSYBITSY .. ; make ; mv u2if.uf2 u2if_itsybitsy.uf2
+          cmake -DBOARD=KB2040 .. ; make ; mv u2if.uf2 u2if_kb2040.uf2
+          cmake -DBOARD=QTPY .. ; make ; mv u2if.uf2 u2if_qtpy.uf2
           cmake -DBOARD=QT2040_TRINKEY .. ; make ; mv u2if.uf2 u2if_trinkey.uf2
-          cmake -DBOARD=FEATHER_EPD .. ; make ; mv u2if.uf2 u2if_trinkey.uf2
-          cmake -DBOARD=FEATHER_RFM .. ; make ; mv u2if.uf2 u2if_trinkey.uf2
-          cmake -DBOARD=FEATHER_CAN .. ; make ; mv u2if.uf2 u2if_trinkey.uf2
-          cmake -DBOARD=KB2040 .. ; make ; mv u2if.uf2 u2if_trinkey.uf2
 
           ls -l u2if_*.uf2
       - name: Add Build Artifacts to CI Run

--- a/firmware/build-all.sh
+++ b/firmware/build-all.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
+# set -x
 
-dirname=${PWD##*/} 
+dirname=${PWD##*/}
 if [ $dirname != "firmware" ]; then
   echo "This script has to be launched in the firmware directory"
   exit -1
@@ -27,11 +28,11 @@ mkdir -p $RELEASE_DIR
 build pico_i2s PICO 1 1 1000 0
 build pico_hub75 PICO 0 1 1000 1
 build feather FEATHER 0 0 1000 0
-build itsybitsy ITSYBITSY 0 0 1000 0
-build qtpy QTPY 0 0 1000 0
-build qt2040_trinkey QT2040_TRINKEY 0 0 1000 0
 build feather_epd FEATHER_EPD 0 1 1000 0
 build feather_rfm FEATHER_RFM 0 1 1000 0
 build feather_can FEATHER_CAN 0 1 1000 0
+build itsybitsy ITSYBITSY 0 0 1000 0
 build kb2040 KB2040 0 1 1000 0
+build qtpy QTPY 0 0 1000 0
+build qt2040_trinkey QT2040_TRINKEY 0 0 1000 0
 

--- a/firmware/build-all.sh
+++ b/firmware/build-all.sh
@@ -27,12 +27,12 @@ function build {
 mkdir -p $RELEASE_DIR
 build pico_i2s PICO 1 1 1000 0
 build pico_hub75 PICO 0 1 1000 1
-build feather FEATHER 0 0 1000 0
+build feather FEATHER 0 1 1000 0
 build feather_epd FEATHER_EPD 0 1 1000 0
 build feather_rfm FEATHER_RFM 0 1 1000 0
 build feather_can FEATHER_CAN 0 1 1000 0
-build itsybitsy ITSYBITSY 0 0 1000 0
+build itsybitsy ITSYBITSY 0 1 1000 0
 build kb2040 KB2040 0 1 1000 0
-build qtpy QTPY 0 0 1000 0
-build qt2040_trinkey QT2040_TRINKEY 0 0 1000 0
+build qtpy QTPY 0 1 1000 0
+build qt2040_trinkey QT2040_TRINKEY 0 1 1000 0
 

--- a/firmware/source/main.cpp
+++ b/firmware/source/main.cpp
@@ -85,7 +85,7 @@ static I2s i2s(4000, 5);
 static Hub75 hub75(HUB75_MAX_LEDS*4);
 #endif
 
-static std::vector<BaseInterface*> interfaces = { 
+static std::vector<BaseInterface*> interfaces = {
 &gpio
 , &group_gpio
 #if I2C0_ENABLED
@@ -238,8 +238,9 @@ void tud_resume_cb(void) {
 // Invoked when received GET_REPORT control request
 // Application must fill buffer report's content and return its length.
 // Return zero will cause the stack to STALL request
-uint16_t tud_hid_get_report_cb(uint8_t report_id, hid_report_type_t report_type, uint8_t *buffer, uint16_t reqlen) {
+uint16_t tud_hid_get_report_cb(uint8_t instance, uint8_t report_id, hid_report_type_t report_type, uint8_t *buffer, uint16_t reqlen) {
     // TODO not Implemented
+    (void) instance;
     (void) report_id;
     (void) report_type;
     (void) buffer;
@@ -250,8 +251,9 @@ uint16_t tud_hid_get_report_cb(uint8_t report_id, hid_report_type_t report_type,
 
 // Invoked when received SET_REPORT control request or
 // received data on OUT endpoint ( Report ID = 0, Type = 0 )
-void tud_hid_set_report_cb(uint8_t report_id, hid_report_type_t report_type, uint8_t const *buffer, uint16_t bufsize) {
+void tud_hid_set_report_cb(uint8_t instance, uint8_t report_id, hid_report_type_t report_type, uint8_t const *buffer, uint16_t bufsize) {
     // This example doesn't use multiple report and report ID
+    (void) instance;
     (void) report_id;
     (void) report_type;
     processCmd(buffer, bufsize);

--- a/firmware/source/usb_descriptors.c
+++ b/firmware/source/usb_descriptors.c
@@ -177,7 +177,7 @@ uint8_t const desc_configuration[] =
                 TUD_CDC_DESCRIPTOR(ITF_NUM_CDC, 4, EPNUM_CDC_NOTIF, 8, EPNUM_CDC_OUT, EPNUM_CDC_IN, 64),
 
                 // Interface number, string index, protocol, report descriptor len, EP In & Out address, size & polling interval
-                TUD_HID_INOUT_DESCRIPTOR(ITF_NUM_HID, 5, HID_PROTOCOL_NONE, sizeof(desc_hid_report), EPNUM_HID,
+                TUD_HID_INOUT_DESCRIPTOR(ITF_NUM_HID, 5, HID_PROTOCOL_BOOT sizeof(desc_hid_report), EPNUM_HID,
                                          0x80 | EPNUM_HID, CFG_TUD_HID_BUFSIZE, /*10*/ 1)
         };
 

--- a/firmware/source/usb_descriptors.c
+++ b/firmware/source/usb_descriptors.c
@@ -177,7 +177,7 @@ uint8_t const desc_configuration[] =
                 TUD_CDC_DESCRIPTOR(ITF_NUM_CDC, 4, EPNUM_CDC_NOTIF, 8, EPNUM_CDC_OUT, EPNUM_CDC_IN, 64),
 
                 // Interface number, string index, protocol, report descriptor len, EP In & Out address, size & polling interval
-                TUD_HID_INOUT_DESCRIPTOR(ITF_NUM_HID, 5, HID_PROTOCOL_BOOT sizeof(desc_hid_report), EPNUM_HID,
+                TUD_HID_INOUT_DESCRIPTOR(ITF_NUM_HID, 5, HID_PROTOCOL_BOOT, sizeof(desc_hid_report), EPNUM_HID,
                                          0x80 | EPNUM_HID, CFG_TUD_HID_BUFSIZE, /*10*/ 1)
         };
 

--- a/firmware/source/usb_descriptors.c
+++ b/firmware/source/usb_descriptors.c
@@ -136,8 +136,10 @@ uint8_t const desc_hid_report[] =
 // Invoked when received GET HID REPORT DESCRIPTOR
 // Application return pointer to descriptor
 // Descriptor contents must exist long enough for transfer to complete
-uint8_t const *tud_hid_descriptor_report_cb(void) {
-    return desc_hid_report;
+uint8_t const *tud_hid_descriptor_report_cb(uint8_t index)
+{
+  (void)index; // for multiple configurations
+  return desc_hid_report;
 }
 
 //--------------------------------------------------------------------+


### PR DESCRIPTION
This adds the following boards to CI that are supported in build-all.sh for issue https://github.com/adafruit/u2if/issues/17

* FEATHER_EPD
* FEATHER_RFM
* FEATHER_CAN
* KB2040

1. Updates pico-sdk to current (2.1.0)
2. The `build_all.sh` is used for desktop testing and not for CI. CI and the build script can fall out of sync
    1. The `build_all.sh` script now builds in alphabetical order and no longer in board_config.h numerical order. That order is just arbitrary in the order board support was added.
    1. The `build_all.sh` was enabling the WS LEDs for the new boards and not for the old ones.

biuld_u2f.yml file reformatted by VSCode plugin to fix indentation of comments.

Built on Mac and GitHub CI

Tested on device: not yet