### PR TITLE
Support for Radxa x4

### DIFF
--- a/firmware/source/board_config.h.in
+++ b/firmware/source/board_config.h.in
@@ -226,6 +226,44 @@
   #define U2IF_UART0_RX 1
 
 //---------------------------------------------------------
+// Radxa-X4
+//---------------------------------------------------------
+#elif BOARD == RADXA_X4
+  // I2C0
+  #define I2C0_ENABLED 1
+  #define U2IF_I2C0_SDA 28
+  #define U2IF_I2C0_SCL 29
+  // I2C1
+  #define I2C1_ENABLED 1
+  #define U2IF_I2C1_SDA 18
+  #define U2IF_I2C1_SCL 19
+  // SPI0
+  #define SPI0_ENABLED 1
+  #define U2IF_SPI0_CK 6
+  #define U2IF_SPI0_MOSI 3
+  #define U2IF_SPI0_MISO 4
+  // SPI1
+  #define SPI1_ENABLED 1
+  #define U2IF_SPI1_CK 10
+  #define U2IF_SPI1_MOSI 11
+  #define U2IF_SPI1_MISO 8
+  // UART0
+  #define UART0_ENABLED 1
+  #define U2IF_UART0_TX 0
+  #define U2IF_UART0_RX 1
+  // UART1
+  #define UART1_ENABLED 1
+  #define U2IF_UART1_TX 20
+  #define U2IF_UART1_RX 21
+  // I2S
+  #define I2S_ENABLED  I2S_ALLOW
+  #define U2IF_I2S_CLK 23
+  #define U2IF_I2S_WS  24
+  #define U2IF_I2S_SD  25
+  // HUB75
+  #define HUB75_ENABLED  HUB75_ALLOW
+
+  //---------------------------------------------------------
 // Pico (default)
 //---------------------------------------------------------
 #elif BOARD == PICO

--- a/firmware/source/interfaces/Adc.cpp
+++ b/firmware/source/interfaces/Adc.cpp
@@ -32,7 +32,7 @@ CmdStatus Adc::task(uint8_t response[64]) {
 }
 
 int8_t Adc::getAdcIndexFromGpio(uint8_t gpio) {
-    if(gpio < 26 || gpio > 28)
+    if(gpio < 26 || gpio > 29)
         return -1;
     else
         return (static_cast<int8_t>(gpio)-26);

--- a/firmware/source/usb_descriptors.c
+++ b/firmware/source/usb_descriptors.c
@@ -85,6 +85,12 @@
   #define USB_VID 0xCAFE
   #define USB_PID           (0x4000 | _PID_MAP(CDC, 0) | _PID_MAP(MSC, 1) | _PID_MAP(HID, 2) | \
                             _PID_MAP(MIDI, 3) | _PID_MAP(VENDOR, 4) )
+#elif BOARD == RADXA_X4
+  #define USB_MFG "Pico"
+  #define USB_PRD "U2IF"
+  #define USB_VID 0xCAFF
+  #define USB_PID           (0x4000 | _PID_MAP(CDC, 0) | _PID_MAP(MSC, 1) | _PID_MAP(HID, 2) | \
+                            _PID_MAP(MIDI, 3) | _PID_MAP(VENDOR, 4) )
 #else
   #warning "Please define board type"
 #endif


### PR DESCRIPTION
The Radxa X4 is an Intel N100 board with a builtin RP2040. This PR adds support for this chip via u2if.

There will be two additional PRs for Adafruit_Blinka and Adafruit_Python_Platformdetect that use this implementation.